### PR TITLE
chore(deps): FORGE-632 upgrade Apache Camel to 4.14.6 to remediate CVEs

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -64,7 +64,7 @@
     <!-- ***END temporary override of versions*** -->
 
     <forge.camel-hippoevt.version>${project.version}</forge.camel-hippoevt.version>
-    <camel.version>4.14.4</camel.version>
+    <camel.version>4.14.6</camel.version>
     <activemq.version>6.1.3</activemq.version>
 
     <httpcore4-version>4.4.14</httpcore4-version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <project.build.javaVersion>17</project.build.javaVersion>
 
-    <camel.version>4.14.4</camel.version>
+    <camel.version>4.14.6</camel.version>
 
     <plugin.jxr.version>3.5.0</plugin.jxr.version>
     <plugin.pmd.version>3.25.0</plugin.pmd.version>


### PR DESCRIPTION
Addresses 7 CVEs in camel-core (4.14.4) including one RCE-class vulnerability (CVE-2026-33454, CVE-2026-40022, CVSS 6.9). Upgrade to 4.14.6 is the safe LTS patch that resolves all reported issues without entering the 4.18/4.19 ranges affected by CVE-2026-40048.
Bumps camel.version in both the plugin (pom.xml) and demo (demo/pom.xml).

(co-authored with Claude Code)